### PR TITLE
Add ProviderRegistry initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,9 @@ my-element.js
 my-element.js.map
 my-element.d.ts
 my-element.d.ts.map
+provider-registry.js
+provider-registry.js.map
+provider-registry.d.ts
+provider-registry.d.ts.map
 # only generated for size check
 my-element.bundled.js

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -1,0 +1,54 @@
+import {Context} from '@lit/context';
+
+export type Token<T> = Context<unknown, T>;
+
+export interface Dep<T> {
+  token: Token<T>;
+  optional?: boolean;
+}
+
+export interface Provider<T = unknown> {
+  token: Token<T>;
+  value?: T;
+  deps?: Dep<unknown>[];
+  factory?: (helpers: {
+    inject: <U>(tok: Token<U>) => Promise<U>;
+    injectOptional: <U>(tok: Token<U>) => Promise<U | undefined>;
+    injectSync: <U>(tok: Token<U>) => U;
+    destroyRef?: DestroyRef;
+  }) => Promise<T> | T;
+  dispose?: (instance: T) => void;
+}
+
+export interface DestroyRef {
+  onDestroy(cb: () => void): void;
+}
+
+/**
+ * Global registry for DI providers.
+ */
+export type AnyProvider = Provider<unknown>;
+
+export class ProviderRegistry {
+  private map = new Map<Token<unknown>, AnyProvider>();
+  private listeners = new Set<(p: AnyProvider) => void>();
+
+  register(...providers: AnyProvider[]) {
+    for (const provider of providers) {
+      this.map.set(provider.token, provider);
+      for (const cb of this.listeners) {
+        cb(provider);
+      }
+    }
+  }
+
+  entries() {
+    return this.map.entries();
+  }
+
+  onNew(cb: (p: AnyProvider) => void) {
+    this.listeners.add(cb);
+  }
+}
+
+export const providerRegistry = new ProviderRegistry();

--- a/src/test/provider-registry_test.ts
+++ b/src/test/provider-registry_test.ts
@@ -1,0 +1,22 @@
+import {assert} from '@open-wc/testing';
+import {createContext} from '@lit/context';
+import {ProviderRegistry, AnyProvider} from '../provider-registry.js';
+
+suite('ProviderRegistry', () => {
+  test('register notifies listeners', () => {
+    const registry = new ProviderRegistry();
+    const token = createContext<number>(Symbol('num'));
+    const provider: AnyProvider = {token, value: 42};
+    let notified: AnyProvider | undefined;
+    registry.onNew(p => {
+      notified = p;
+    });
+
+    registry.register(provider);
+
+    assert.strictEqual(notified, provider);
+    const entry = Array.from(registry.entries()).find(([t]) => t === token);
+    assert.ok(entry);
+    assert.strictEqual(entry![1], provider);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a DI ProviderRegistry singleton
- add a basic test for ProviderRegistry
- ignore compiled registry artifacts

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_683ce0bed3d08320b8aa126389d3ba49