### PR TITLE
Implement DestroyRef step

### DIFF
--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -1,6 +1,11 @@
-import {Context} from '@lit/context';
+import {Context, createContext} from '@lit/context';
 
 export type Token<T> = Context<unknown, T>;
+
+/** Destroy-ref token */
+export const DESTROY_REF: Token<DestroyRef> = createContext<DestroyRef>(
+  Symbol('DestroyRef')
+);
 
 export interface Dep<T> {
   token: Token<T>;
@@ -20,8 +25,19 @@ export interface Provider<T = unknown> {
   dispose?: (instance: T) => void;
 }
 
-export interface DestroyRef {
-  onDestroy(cb: () => void): void;
+export class DestroyRef {
+  private callbacks = new Set<() => void>();
+
+  onDestroy(cb: () => void): void {
+    this.callbacks.add(cb);
+  }
+
+  destroy(): void {
+    for (const cb of this.callbacks) {
+      cb();
+    }
+    this.callbacks.clear();
+  }
 }
 
 /**

--- a/src/test/destroy-ref_test.ts
+++ b/src/test/destroy-ref_test.ts
@@ -1,0 +1,25 @@
+import {assert} from '@open-wc/testing';
+import {DestroyRef, DESTROY_REF} from '../provider-registry.js';
+
+console.log('destroy-ref test loaded');
+
+suite('DestroyRef', () => {
+  test('runs callbacks on destroy', () => {
+    const dr = new DestroyRef();
+    let called = 0;
+    dr.onDestroy(() => {
+      called++;
+    });
+    dr.onDestroy(() => {
+      called++;
+    });
+
+    dr.destroy();
+
+    assert.equal(called, 2);
+  });
+
+  test('exports DESTROY_REF token', () => {
+    assert.ok(DESTROY_REF);
+  });
+});


### PR DESCRIPTION
## Summary
- add `DestroyRef` class and `DESTROY_REF` token
- debug DestroyRef unit test so suite completes

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_683ce2fe93f88320bad5aa38f386525b