### PR TITLE
Implement RootInjector core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@ provider-registry.js
 provider-registry.js.map
 provider-registry.d.ts
 provider-registry.d.ts.map
+root-injector.js
+root-injector.js.map
+root-injector.d.ts
+root-injector.d.ts.map
 # only generated for size check
 my-element.bundled.js

--- a/src/root-injector.ts
+++ b/src/root-injector.ts
@@ -1,0 +1,95 @@
+import {Context, ContextEvent, ContextRoot} from '@lit/context';
+import {providerRegistry, Provider, Token, DestroyRef} from './provider-registry.js';
+
+/** Root injector for Lit-DI. */
+export class RootInjector extends ContextRoot {
+  private host: HTMLElement;
+  private providers = new Map<Token<unknown>, Provider<unknown>>();
+  private instances = new Map<Token<unknown>, unknown>();
+  private destroyRef = new DestroyRef();
+  private localTokens = new Set<Token<unknown>>();
+
+  constructor(host: HTMLElement, providers: Provider[] = []) {
+    super();
+    this.host = host;
+
+    for (const [token, provider] of providerRegistry.entries()) {
+      this.providers.set(token as Token<unknown>, provider as Provider<unknown>);
+    }
+    for (const p of providers) {
+      this.providers.set(p.token as Token<unknown>, p as Provider<unknown>);
+      this.localTokens.add(p.token as Token<unknown>);
+    }
+
+    providerRegistry.onNew(p => {
+      if (this.localTokens.has(p.token as Token<unknown>)) {
+        return;
+      }
+      this.providers.set(p.token as Token<unknown>, p as Provider<unknown>);
+    });
+
+    this.attach(host);
+    host.addEventListener('context-request', this.handleRequest as EventListener);
+  }
+
+  private handleRequest = (event: Event): void => {
+    const e = event as ContextEvent<Context<unknown, unknown>>;
+    const token = e.context as Token<unknown>;
+    const provider = this.providers.get(token);
+    if (!provider) {
+      return;
+    }
+    e.stopPropagation();
+    const result = this.resolve(token, provider);
+    if (result instanceof Promise) {
+      result.then(v => e.callback(v as unknown));
+    } else {
+      e.callback(result as unknown);
+    }
+  }
+
+  private resolve<T>(token: Token<T>, provider: Provider<T>): T | Promise<T> {
+    if (this.instances.has(token)) {
+      return this.instances.get(token) as T;
+    }
+    let value: T | Promise<T>;
+    if (provider.value !== undefined) {
+      value = provider.value as T;
+    } else if (provider.factory) {
+      value = provider.factory({
+        inject: async () => {
+          throw new Error('inject not implemented');
+        },
+        injectOptional: async () => undefined,
+        injectSync: () => {
+          throw new Error('injectSync not implemented');
+        },
+      }) as T | Promise<T>;
+    } else {
+      throw new Error('Provider missing value or factory');
+    }
+    if (value instanceof Promise) {
+      return value.then(v => {
+        this.instances.set(token, v);
+        return v;
+      });
+    }
+    this.instances.set(token, value as T);
+    return value as T;
+  }
+
+  /** Dispose all provider instances and detach listeners. */
+  disposeAll(): void {
+    for (const [token, instance] of this.instances) {
+      const provider = this.providers.get(token);
+      if (provider?.dispose) {
+        provider.dispose(instance as unknown);
+      }
+    }
+    this.instances.clear();
+    this.host.removeEventListener('context-request', this.handleRequest as EventListener);
+    this.detach(this.host);
+    this.destroyRef.destroy();
+  }
+}
+

--- a/src/test/root-injector_test.ts
+++ b/src/test/root-injector_test.ts
@@ -1,0 +1,72 @@
+import {assert} from '@open-wc/testing';
+import {createContext, ContextEvent} from '@lit/context';
+import {RootInjector} from '../root-injector.js';
+import {providerRegistry, Provider} from '../provider-registry.js';
+
+suite('RootInjector', () => {
+  test('resolves value provider from registry', () => {
+    const token = createContext<number>(Symbol('num'));
+    const provider: Provider<number> = {token, value: 42};
+    providerRegistry.register(provider as any);
+    const host = document.createElement('div');
+    const injector = new RootInjector(host);
+    let result: number | undefined;
+    host.dispatchEvent(new ContextEvent(token, host, (v: number) => (result = v)));
+    assert.equal(result, 42);
+    injector.disposeAll();
+  });
+
+  test('caches factory result', () => {
+    const token = createContext<number>(Symbol('num2'));
+    let calls = 0;
+    const provider: Provider<number> = {
+      token,
+      factory: () => {
+        calls++;
+        return 7;
+      },
+    };
+    providerRegistry.register(provider as any);
+    const host = document.createElement('div');
+    const injector = new RootInjector(host);
+    let v1: number | undefined;
+    host.dispatchEvent(new ContextEvent(token, host, (v: number) => (v1 = v)));
+    let v2: number | undefined;
+    host.dispatchEvent(new ContextEvent(token, host, (v: number) => (v2 = v)));
+    assert.equal(calls, 1);
+    assert.equal(v1, 7);
+    assert.equal(v2, 7);
+    injector.disposeAll();
+  });
+
+  test('disposeAll calls provider dispose', () => {
+    const token = createContext<number>(Symbol('num3'));
+    let disposed = false;
+    const provider: Provider<number> = {
+      token,
+      value: 1,
+      dispose: () => {
+        disposed = true;
+      },
+    };
+    providerRegistry.register(provider as any);
+    const host = document.createElement('div');
+    const injector = new RootInjector(host);
+    host.dispatchEvent(new ContextEvent(token, host, () => {}));
+    injector.disposeAll();
+    assert.isTrue(disposed);
+  });
+
+  test('registry onNew does not override constructor provider', () => {
+    const token = createContext<number>(Symbol('num4'));
+    const localProvider: Provider<number> = {token, value: 5};
+    const host = document.createElement('div');
+    const injector = new RootInjector(host, [localProvider as any]);
+    const globalProvider: Provider<number> = {token, value: 9};
+    providerRegistry.register(globalProvider as any);
+    let result: number | undefined;
+    host.dispatchEvent(new ContextEvent(token, host, v => (result = v)));
+    assert.equal(result, 5);
+    injector.disposeAll();
+  });
+});


### PR DESCRIPTION
## Summary
- add RootInjector implementation and unit tests
- generate compiled JS/typings for RootInjector
- prevent providerRegistry.onNew from overriding constructor providers
- add tests and ignore compiled output

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_683ce916496083209999c6723f454671